### PR TITLE
Use locally served emojis.png.

### DIFF
--- a/assets/_data/style.css
+++ b/assets/_data/style.css
@@ -197,7 +197,7 @@ span.emoji-inner {
 	overflow: hidden;
 	width: 100%;
 	height: 100%;
-	background: url(https://dl.dropboxusercontent.com/u/8554242/temp/emojis.png);
+	background: url(/emojis/emojis.png);
 	background-size: 4100% !important;
 	vertical-align: middle;
 }
@@ -271,7 +271,7 @@ span.rm-emoji {
 	display: inline-block;
 	width: 22px;
 	height: 22px;
-	background: url(https://dl.dropboxusercontent.com/u/8554242/temp/emojis.png);
+	background: url(/emojis/emojis.png);
 	background-size: 4100%;
 }
 span.rm-large {

--- a/main.go
+++ b/main.go
@@ -70,8 +70,16 @@ type handler struct {
 	Options
 }
 
+// TODO: Find a better way for issuesapp to be able to ensure registration of a top-level route:
+//
+// 	emojisHandler := httpgzip.FileServer(emojis.Assets, httpgzip.FileServerOptions{ServeError: httpgzip.Detailed})
+// 	http.Handle("/emojis/", http.StripPrefix("/emojis", emojisHandler))
+//
+// So that it can depend on it.
+
 // New returns an issues app http.Handler using given services and options.
 // If usersService is nil, then there is no way to have an authenticated user.
+// Emojis image data is expected to be available at /emojis/emojis.png.
 func New(service issues.Service, usersService users.Service, opt Options) http.Handler {
 	handler := &handler{
 		is:      service,


### PR DESCRIPTION
It's more performant to serve them from same host (less FOUC). Also, dropbox HTTP file hosting may be going away. Using a .png file hosted on Dropbox is janky either way, so I want to get rid of it.

I _would_ like to find a better way of doing this. The current solution makes the API of this package harder to use by adding a precondition. It requires user to add some code to use this package:

``` Go
import "github.com/shurcooL/reactions/emojis"
```

``` Go
emojisHandler := httpgzip.FileServer(emojis.Assets, httpgzip.FileServerOptions{})
http.Handle("/emojis/", http.StripPrefix("/emojis", emojisHandler))
```

(See [here](https://github.com/shurcooL/home/commit/50452cef9d036a831463208b18aebf012b9def7b#diff-2) for real example.)

Ideally, that code would primarily live here, inside this library. But that would require some common external interface to "register" resources at a globally available location for the frontend to use.

I'm not quite ready and don't have an ideal solution for that, hence this in-between solution for now. Improvement suggestions are welcome.
