### PR TITLE
Simplify API.

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,9 +58,6 @@ type Options struct {
 
 	// BodyTop provides components to include on top of <body> of page rendered for req. It can be nil.
 	BodyTop func(req *http.Request) ([]htmlg.ComponentContext, error)
-
-	// TODO.
-	BaseState func(req *http.Request) BaseState
 }
 
 type handler struct {
@@ -197,10 +194,25 @@ type BaseState struct {
 }
 
 func (h *handler) baseState(req *http.Request) (BaseState, error) {
-	b := h.BaseState(req)
+	repoSpec := h.RepoSpec(req)
+	baseURI := h.BaseURI(req)
+
+	// TODO: Caller still does a lot of work outside to calculate req.URL.Path by
+	//       subtracting BaseURI from full original req.URL.Path. We should be able
+	//       to compute it here internally by using req.RequestURI and BaseURI.
+	reqPath := req.URL.Path
+	if reqPath == "/" {
+		reqPath = "" // This is needed so that absolute URL for root view, i.e., /issues, is "/issues" and not "/issues/" because of "/issues" + "/".
+	}
+	b := BaseState{
+		State: common.State{
+			BaseURI: baseURI,
+			ReqPath: reqPath,
+		},
+	}
 	b.req = req
 	b.vars = mux.Vars(req)
-	b.repoSpec = h.RepoSpec(req)
+	b.repoSpec = repoSpec
 	b.HeadPre = h.HeadPre
 	if h.BodyTop != nil {
 		c, err := h.BodyTop(req)


### PR DESCRIPTION
Remove difficult to understand and use options.

Experimentally (as in, I'm not sure if this is the best long term solution, but it's an improvement over the current mess), rely on context keys to provide two mandatory parameters to the issuesapp HTTP handler.

Previously, one had to do something like:

```Go
opt := issuesapp.Options{
	RepoSpec: func(req *http.Request) issues.RepoSpec {
		return req.Context().Value(issuesapp.RepoSpecContextKey).(issues.RepoSpec)
	},
	BaseURI: func(req *http.Request) string {
		return req.Context().Value(issuesapp.BaseURIContextKey).(string)
	},
	...
}
```

Or constant values in the case of `servegoissues`.

Now it's not needed. But need to set those values in the request context (as was being done before in most cases anyway):

```Go
http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
	req = req.WithContext(context.WithValue(req.Context(), issuesapp.RepoSpecContextKey, issues.RepoSpec{...}))
	req = req.WithContext(context.WithValue(req.Context(), issuesapp.BaseURIContextKey, string(...)))
	issuesApp.ServeHTTP(w, req)
})
```